### PR TITLE
Fix an issue with not saving Google Ad slot id

### DIFF
--- a/jp-minileven-ads.php
+++ b/jp-minileven-ads.php
@@ -224,7 +224,7 @@ function jp_mini_ads_do_page() {
 function jp_mini_ads_validate( $input ) {
 
 	$input['google_ad_client']  = wp_filter_nohtml_kses( $input['google_ad_client'] );
-	$input['google_ad_slot']    = absint( $input['google_ad_slot'] );
+	$input['google_ad_slot']    = sanitize_key( $input['google_ad_slot'] );
 	$input['google_ad_width']   = absint( $input['google_ad_width'] );
 	$input['google_ad_height']  = absint( $input['google_ad_height'] );
 


### PR DESCRIPTION
Fix an issue with not saving Google Ad slot id when it is greater than 2147483647.
https://wordpress.org/support/topic/cannot-save-my-google_ad_slot-id
